### PR TITLE
Change unique identifier of a Pet to be its Name

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -38,7 +38,11 @@ jacocoTestReport {
 }
 
 test {
-    useJUnitPlatform()
+    useJUnitPlatform()    
+    testLogging {
+        events "failed"
+        exceptionFormat "full"
+    }
 }
 
 dependencies {

--- a/build.gradle
+++ b/build.gradle
@@ -38,7 +38,7 @@ jacocoTestReport {
 }
 
 test {
-    useJUnitPlatform()    
+    useJUnitPlatform()
     testLogging {
         events "failed"
         exceptionFormat "full"

--- a/src/main/java/seedu/address/model/pet/Pet.java
+++ b/src/main/java/seedu/address/model/pet/Pet.java
@@ -67,7 +67,7 @@ public class Pet {
     }
 
     /**
-     * Returns true if both pets of the same name and gender have at least one other identity field that is the same.
+     * Returns true if both pets have the same name.
      * This defines a weaker notion of equality between two pets.
      */
     public boolean isSamePet(Pet otherPet) {
@@ -75,10 +75,7 @@ public class Pet {
             return true;
         }
 
-        return otherPet != null
-                && otherPet.getName().equals(getName())
-                && otherPet.getSpecies().equals(getSpecies())
-                && (otherPet.getDateOfBirth().equals(getDateOfBirth()) || otherPet.getGender().equals(getGender()));
+        return otherPet != null && otherPet.getName().equals(getName());
     }
 
     /**

--- a/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
+++ b/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
@@ -29,6 +29,8 @@ public class CommandTestUtil {
 
     public static final String VALID_NAME_AMY = "Amy Bee";
     public static final String VALID_NAME_BOB = "Bob Choo";
+    public static final String VALID_NAME_COCO = "Coco";
+    public static final String VALID_NAME_GARFIELD = "Garfield Arbuckle";
     public static final String VALID_PHONE_AMY = "11111111";
     public static final String VALID_PHONE_BOB = "22222222";
     public static final Gender VALID_GENDER_COCO = Gender.FEMALE;

--- a/src/test/java/seedu/address/model/pet/PetTest.java
+++ b/src/test/java/seedu/address/model/pet/PetTest.java
@@ -4,12 +4,12 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_DOB_GARFIELD;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_GENDER_GARFIELD;
-import static seedu.address.logic.commands.CommandTestUtil.VALID_NAME_BOB;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_NAME_GARFIELD;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_SPECIES_GARFIELD;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_TAG_FAT;
 import static seedu.address.testutil.Assert.assertThrows;
-import static seedu.address.testutil.TypicalPets.BOB;
 import static seedu.address.testutil.TypicalPets.COCO;
+import static seedu.address.testutil.TypicalPets.GARFIELD;
 
 import org.junit.jupiter.api.Test;
 
@@ -31,21 +31,26 @@ public class PetTest {
         // null -> returns false
         assertFalse(COCO.isSamePet(null));
 
-        // different gender and date of birth -> returns false
-        Pet editedCoco = new PetBuilder(COCO).withGender(VALID_GENDER_GARFIELD).withDateOfBirth(VALID_DOB_GARFIELD)
-                .build();
-        assertFalse(COCO.isSamePet(editedCoco));
-
         // different name -> returns false
-        editedCoco = new PetBuilder(COCO).withName(VALID_NAME_BOB).build();
+        Pet editedCoco = new PetBuilder(COCO).withName(VALID_NAME_GARFIELD).build();
         assertFalse(COCO.isSamePet(editedCoco));
 
-        // different species -> returns false
+        // different species -> returns true
         editedCoco = new PetBuilder(COCO).withSpecies(VALID_SPECIES_GARFIELD).build();
-        assertFalse(COCO.isSamePet(editedCoco));
+        assertTrue(COCO.isSamePet(editedCoco));
 
         // same name, same gender, same date of birth, same species, different foodList -> returns true
         // TBD after SampleDataUtil is finished!
+
+        // different gender and date of birth -> returns true
+        editedCoco = new PetBuilder(COCO).withGender(VALID_GENDER_GARFIELD).withDateOfBirth(VALID_DOB_GARFIELD)
+                .build();
+        assertTrue(COCO.isSamePet(editedCoco));
+
+        // same name, different gender, different date of birth, different species, different  tags -> returns true
+        editedCoco = new PetBuilder(COCO).withGender(VALID_GENDER_GARFIELD).withDateOfBirth(VALID_DOB_GARFIELD)
+                .withSpecies(VALID_SPECIES_GARFIELD).withTags(VALID_TAG_FAT).build();
+        assertTrue(COCO.isSamePet(editedCoco));
 
         // same name, same gender, same date of birth, same species, different tags -> returns true
         editedCoco = new PetBuilder(COCO).withTags(VALID_TAG_FAT).build();
@@ -68,10 +73,10 @@ public class PetTest {
         assertFalse(COCO.equals(5));
 
         // different person -> returns false
-        assertFalse(COCO.equals(BOB));
+        assertFalse(COCO.equals(GARFIELD));
 
         // different name -> returns false
-        Pet editedCoco = new PetBuilder(COCO).withName(VALID_NAME_BOB).build();
+        Pet editedCoco = new PetBuilder(COCO).withName(VALID_NAME_GARFIELD).build();
         assertFalse(COCO.equals(editedCoco));
 
         // different gender -> returns false

--- a/src/test/java/seedu/address/testutil/PetBuilder.java
+++ b/src/test/java/seedu/address/testutil/PetBuilder.java
@@ -13,7 +13,7 @@ import seedu.address.model.tag.Tag;
 import seedu.address.model.util.SampleDataUtil;
 
 /**
- * A utility class to help with building Person objects.
+ * A utility class to help with building Pet objects.
  */
 public class PetBuilder {
 
@@ -39,7 +39,7 @@ public class PetBuilder {
     }
 
     /**
-     * Initializes the PersonBuilder with the data of {@code petToCopy}.
+     * Initializes the PetBuilder with the data of {@code petToCopy}.
      */
     public PetBuilder(Pet petToCopy) {
         name = petToCopy.getName();
@@ -51,7 +51,7 @@ public class PetBuilder {
     }
 
     /**
-     * Sets the {@code Name} of the {@code Person} that we are building.
+     * Sets the {@code Name} of the {@code Pet} that we are building.
      */
     public PetBuilder withName(String name) {
         this.name = new Name(name);
@@ -59,7 +59,7 @@ public class PetBuilder {
     }
 
     /**
-     * Parses the {@code tags} into a {@code Set<Tag>} and set it to the {@code Person} that we are building.
+     * Parses the {@code tags} into a {@code Set<Tag>} and set it to the {@code Pet} that we are building.
      */
     public PetBuilder withTags(String ... tags) {
         this.tags = SampleDataUtil.getTagSet(tags);
@@ -67,15 +67,15 @@ public class PetBuilder {
     }
 
     /**
-     * Sets the {@code Address} of the {@code Person} that we are building.
+     * Sets the {@code Species} of the {@code Pet} that we are building.
      */
-    public PetBuilder withSpecies(String address) {
-        this.species = new Species(address);
+    public PetBuilder withSpecies(String species) {
+        this.species = new Species(species);
         return this;
     }
 
     /**
-     * Sets the {@code Phone} of the {@code Person} that we are building.
+     * Sets the {@code Gender} of the {@code Pet} that we are building.
      */
     public PetBuilder withGender(Gender gender) {
         this.gender = gender;
@@ -83,7 +83,7 @@ public class PetBuilder {
     }
 
     /**
-     * Sets the {@code Email} of the {@code Person} that we are building.
+     * Sets the {@code DateOfBirth} of the {@code Pet} that we are building.
      */
     public PetBuilder withDateOfBirth(String dob) {
         this.dob = new DateOfBirth(dob);


### PR DESCRIPTION
Modified the isSamePet method of Pet such that the check now depends
solely on the names of the pets, instead of using names, species, and
dates of birth or genders. This is to allow a pet to be uniquely
identified by its name, and also enforces a one-to-one relation between
a name and a pet because UniquePetList does not allow duplicates.